### PR TITLE
refactor: extract API helpers and stack scripts

### DIFF
--- a/sharkey_ads/apis/mastodon.py
+++ b/sharkey_ads/apis/mastodon.py
@@ -1,0 +1,49 @@
+import requests
+from urllib.parse import quote
+
+TIMEOUT = 15
+HEADERS = {"User-Agent": "BubbleTrends/1.1 (+https://mypocketpals.online)"}
+
+def _get_json(url, params=None):
+    try:
+        r = requests.get(url, headers=HEADERS, params=params or {}, timeout=TIMEOUT)
+        r.raise_for_status()
+        return r.json()
+    except Exception:
+        return None
+
+def get_trends(domain, limit=20):
+    """Return [(tag, score), ...] for Mastodon instance."""
+    url = f"https://{domain}/api/v1/trends/tags"
+    data = _get_json(url, params={"limit": limit})
+    tags = []
+    if isinstance(data, list):
+        for item in data:
+            name = (item.get("name") or "").strip()
+            score = 0
+            for h in (item.get("history") or []):
+                try:
+                    score += int(h.get("uses", 0))
+                except Exception:
+                    pass
+            if not score:
+                score = 1
+            if name:
+                tags.append((name, score))
+    return tags
+
+def tag_timeline(domain, tag, limit=40):
+    """Return list of statuses for a hashtag."""
+    safe = quote(tag.lstrip("#"), safe="")
+    url = f"https://{domain}/api/v1/timelines/tag/{safe}"
+    return _get_json(url, params={"limit": limit}) or []
+
+def pick_image(post):
+    """Return (url, alt_text) for first image attachment in status."""
+    for a in (post.get("media_attachments") or []):
+        if (a.get("type") or "").lower() == "image":
+            url = a.get("remote_url") or a.get("url") or a.get("preview_url")
+            alt = a.get("description") or ""
+            if url:
+                return url, alt
+    return None, None

--- a/sharkey_ads/apis/misskey.py
+++ b/sharkey_ads/apis/misskey.py
@@ -1,0 +1,76 @@
+import requests
+
+TIMEOUT = 15
+HEADERS = {"User-Agent": "BubbleTrends/1.1 (+https://mypocketpals.online)"}
+
+def _get_json(url, method="GET", json_body=None):
+    try:
+        if method == "GET":
+            r = requests.get(url, headers=HEADERS, timeout=TIMEOUT)
+        else:
+            r = requests.post(url, headers={"Content-Type":"application/json", **HEADERS},
+                              json=json_body or {}, timeout=TIMEOUT)
+        r.raise_for_status()
+        return r.json()
+    except Exception:
+        return None
+
+def get_trends(domain, limit=20):
+    """Return [(tag, score), ...] for Misskey/Sharkey instance."""
+    base = f"https://{domain}/api/hashtags/trend"
+    data = _get_json(base, "GET") or _get_json(base, "POST", {"limit": limit})
+    tags = []
+    if isinstance(data, list):
+        for item in data:
+            if isinstance(item, str):
+                tags.append((item, 1))
+            elif isinstance(item, dict):
+                name = item.get("tag") or item.get("name") or item.get("hashtag")
+                score = 0
+                if isinstance(item.get("count"), int):
+                    score = item["count"]
+                elif isinstance(item.get("chart"), list):
+                    for v in item["chart"]:
+                        try:
+                            score += int(v)
+                        except Exception:
+                            pass
+                if not score:
+                    score = 1
+                if name:
+                    tags.append((name, score))
+    return tags
+
+def tag_timeline(domain, tag, limit=40):
+    """Return list of notes for a hashtag."""
+    base = f"https://{domain}/api"
+    try:
+        r = requests.post(f"{base}/notes/search-by-tag",
+                         json={"tag": tag, "limit": limit},
+                         headers=HEADERS, timeout=TIMEOUT)
+        if r.status_code == 200:
+            return r.json() or []
+    except Exception:
+        pass
+    try:
+        r = requests.post(f"{base}/notes/search",
+                         json={"query": f"#{tag}", "limit": limit},
+                         headers=HEADERS, timeout=TIMEOUT)
+        if r.status_code == 200:
+            return r.json() or []
+    except Exception:
+        pass
+    return []
+
+def pick_image(post):
+    """Return (url, alt_text) for first safe image file in note."""
+    for f in (post.get("files") or []):
+        if f.get("isSensitive") is True:
+            continue
+        ctype = (f.get("type") or f.get("contentType") or "").lower()
+        if ctype.startswith("image/"):
+            url = f.get("url") or f.get("thumbnailUrl")
+            alt = f.get("comment") or f.get("name") or ""
+            if url:
+                return url, alt
+    return None, None

--- a/sharkey_ads/images.py
+++ b/sharkey_ads/images.py
@@ -1,0 +1,33 @@
+import argparse
+from .apis import mastodon as mastodon_api, misskey as misskey_api
+
+def main():
+    ap = argparse.ArgumentParser(description="Fetch images from tag timelines")
+    sub = ap.add_subparsers(dest="stack", required=True)
+
+    p_masto = sub.add_parser("mastodon", help="Scan Mastodon hashtag timeline")
+    p_masto.add_argument("domain")
+    p_masto.add_argument("tag")
+    p_masto.add_argument("--limit", type=int, default=40)
+
+    p_miss = sub.add_parser("misskey", help="Scan Misskey/Sharkey hashtag timeline")
+    p_miss.add_argument("domain")
+    p_miss.add_argument("tag")
+    p_miss.add_argument("--limit", type=int, default=40)
+
+    args = ap.parse_args()
+    if args.stack == "mastodon":
+        posts = mastodon_api.tag_timeline(args.domain, args.tag, args.limit)
+        for p in posts:
+            url, alt = mastodon_api.pick_image(p)
+            if url:
+                print(f"{url}\t{alt or ''}")
+    else:
+        posts = misskey_api.tag_timeline(args.domain, args.tag, args.limit)
+        for n in posts:
+            url, alt = misskey_api.pick_image(n)
+            if url:
+                print(f"{url}\t{alt or ''}")
+
+if __name__ == "__main__":
+    main()

--- a/sharkey_ads/trends.py
+++ b/sharkey_ads/trends.py
@@ -1,0 +1,26 @@
+import argparse
+from .apis import mastodon as mastodon_api, misskey as misskey_api
+
+def main():
+    ap = argparse.ArgumentParser(description="Fetch trending tags from a domain")
+    sub = ap.add_subparsers(dest="stack", required=True)
+
+    p_masto = sub.add_parser("mastodon", help="Fetch Mastodon trends")
+    p_masto.add_argument("domain")
+    p_masto.add_argument("--limit", type=int, default=20)
+
+    p_miss = sub.add_parser("misskey", help="Fetch Misskey/Sharkey trends")
+    p_miss.add_argument("domain")
+    p_miss.add_argument("--limit", type=int, default=20)
+
+    args = ap.parse_args()
+    if args.stack == "mastodon":
+        tags = mastodon_api.get_trends(args.domain, args.limit)
+    else:
+        tags = misskey_api.get_trends(args.domain, args.limit)
+
+    for name, score in tags:
+        print(f"{name}\t{score}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Mastodon and Misskey API helper modules with trend, timeline, and image utilities
- simplify bubble_trends and ads_stage_uploads by importing shared helpers
- add `trends` and `images` CLI tools for per-stack operations

## Testing
- `python -m py_compile sharkey_ads/apis/mastodon.py sharkey_ads/apis/misskey.py sharkey_ads/bubble_trends.py sharkey_ads/ads_stage_uploads.py sharkey_ads/trends.py sharkey_ads/images.py`
- `python -m sharkey_ads.trends --help`
- `python -m sharkey_ads.images --help`
- `python -m sharkey_ads.bubble_trends --help`


------
https://chatgpt.com/codex/tasks/task_e_68a87e26805083279ced38279ab96a37