### PR TITLE
Refactor to use Mastodon.py for federated API access

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests==2.32.4
 fastapi==0.111.0
 uvicorn[standard]==0.29.0
 jinja2==3.1.6
+Mastodon.py==2.1.3


### PR DESCRIPTION
## Summary
- replace manual HTTP calls with Mastodon.py in Mastodon and Misskey API helpers
- add Mastodon.py dependency for Fediverse interactions

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b8a71264b48327b639e3f2e76616c8