### PR TITLE
feat: add interactive ad pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # sharkey_hashtag_trends_ads
 
-Surface **bubble-wide trending tags** and turn them into **Sharkey/Misskey advertisements** that link to your local tag pages.
+Surface **seed-list trending tags** and turn them into **Sharkey/Misskey advertisements** that link to your local tag pages.
 
 ## What it does
 
-- **Discover trending hashtags** across the servers you trust (your “bubble”).  
+- **Discover trending hashtags** across the servers you trust (your seed list).
 - For each tag you pick, **select a representative safe image** (consensus across servers first; otherwise the most‑engaged post).  
 - **Deduplicate** by SHA‑256 so the same image isn’t uploaded twice.  
 - **Upload** the image to your server’s **Drive › Advertisements** folder (creating it if missing).  
@@ -37,7 +37,7 @@ cp .env.example .env
    mastodon.art
    ```
 
-2) **Aggregate trends & choose tags** (writes `bubble_trends.json` + `selected_tags.txt`):
+2) **Aggregate trends from your seed list & choose tags** (writes `bubble_trends.json` + `selected_tags.txt`):
 ```bash
 python -m sharkey_ads.bubble_trends --select 10
 # Or pick interactively:
@@ -70,7 +70,7 @@ python -m sharkey_ads.clean_ads_folder --yes
 ## Scripts & switches
 
 ### 1) `bubble_trends`
-Merges trending tags across your bubble and lets you pick a subset.
+Merges trending tags across your seed list and lets you pick a subset.
 
 **CLI**
 - `--domains-file PATH`  (default: `trendy_domains.txt`)
@@ -170,7 +170,7 @@ SHARKEY_TOKEN=YOUR_ADMIN_API_TOKEN_HERE
 AD_FOLDER=Advertisements  # storage folder; created automatically if missing
 STATUS_SCAN_LIMIT=60
 HTTP_TIMEOUT=25
-USER_AGENT=BubbleAdUploader/1.3 (+https://your-domain)
+USER_AGENT=SeedAdUploader/1.3 (+https://your-domain)
 
 # Dedupe behaviour: reuse | rename
 DEDUP_MODE=reuse
@@ -202,7 +202,7 @@ Required token scopes (typical for Sharkey/Misskey forks):
 
 - **Attribution & provenance:** Images are sourced from public posts on other servers. Consider adding attribution (origin domain + post URL) to the ad memo or Drive file description if your policies require it.
 - **NSFW is best‑effort:** Filters avoid obvious NSFW via content warnings, tags, and common terms. They are not perfect. Review before publishing in sensitive contexts.
-- **Neighborly rate limits:** Add small delays between requests if you expand your bubble; some servers rate limit aggressively.
+- **Neighborly rate limits:** Add small delays between requests if you expand your seed list; some servers rate limit aggressively.
 - **Timezones:** `startsAt`/`expiresAt` are sent in UTC; your UI may show local time.
 - **Production hygiene:** Prefer updating/rotating ads over deleting Drive media. Deleting files breaks ads that reference them.
 

--- a/env.example
+++ b/env.example
@@ -8,7 +8,7 @@ SHARKEY_TOKEN=YOUR_ADMIN_API_TOKEN_HERE
 AD_FOLDER=Advertisements  # storage folder; created automatically if missing
 STATUS_SCAN_LIMIT=60
 HTTP_TIMEOUT=25
-USER_AGENT=BubbleAdUploader/1.3 (+https://your-domain)
+USER_AGENT=SeedAdUploader/1.3 (+https://your-domain)
 
 # Dedupe behaviour: reuse | rename
 DEDUP_MODE=reuse

--- a/sharkey_ads/ads_stage_uploads.py
+++ b/sharkey_ads/ads_stage_uploads.py
@@ -17,7 +17,7 @@ SHARKEY_BASE = os.getenv("SHARKEY_BASE", "https://mypocketpals.online").rstrip("
 SHARKEY_TOKEN = (os.getenv("SHARKEY_TOKEN") or "").strip()
 AD_FOLDER = os.getenv("AD_FOLDER", "Advertisements")
 STATUS_SCAN_LIMIT = int(os.getenv("STATUS_SCAN_LIMIT", "60"))
-USER_AGENT = os.getenv("USER_AGENT", "BubbleAdUploader/1.3 (+https://mypocketpals.online)")
+USER_AGENT = os.getenv("USER_AGENT", "SeedAdUploader/1.3 (+https://mypocketpals.online)")
 TIMEOUT = int(os.getenv("HTTP_TIMEOUT", "25"))
 DEDUP_MODE = (os.getenv("DEDUP_MODE", "reuse") or "reuse").lower()  # reuse | rename
 
@@ -103,7 +103,7 @@ def guess_ext_from_bytes_or_url(content_type, url):
         return ext2
     return ".jpg"
 
-# ---------- fetch from bubble servers ----------
+# ---------- fetch from seed list servers ----------
 def detect_stack(domain):
     if mastodon_api.get_trends(domain, limit=1):
         return "mastodon"

--- a/sharkey_ads/apis/mastodon.py
+++ b/sharkey_ads/apis/mastodon.py
@@ -2,7 +2,7 @@ from mastodon import Mastodon
 from urllib.parse import quote
 
 TIMEOUT = 15
-USER_AGENT = "BubbleTrends/1.1 (+https://mypocketpals.online)"
+USER_AGENT = "SeedTrends/1.1 (+https://mypocketpals.online)"
 
 def _client(domain):
     """Return a Mastodon API client for the given domain."""

--- a/sharkey_ads/apis/misskey.py
+++ b/sharkey_ads/apis/misskey.py
@@ -1,7 +1,7 @@
 from mastodon import Mastodon
 
 TIMEOUT = 15
-USER_AGENT = "BubbleTrends/1.1 (+https://mypocketpals.online)"
+USER_AGENT = "SeedTrends/1.1 (+https://mypocketpals.online)"
 
 def _client(domain):
     """Return a Mastodon API client for the given Misskey/Sharkey domain."""

--- a/sharkey_ads/bubble_trends.py
+++ b/sharkey_ads/bubble_trends.py
@@ -1,5 +1,5 @@
 # bubble_trends.py
-# Aggregate trending hashtags across your bubble servers and pick a subset for the next step.
+# Aggregate trending hashtags across your seed list servers and pick a subset for the next step.
 # Usage:
 #   1) Create trendy_domains.txt with one domain per line (e.g. mastodon.social, misskey.io)
 #   2) python -m sharkey_ads.bubble_trends --select 12
@@ -78,7 +78,7 @@ def fetch_domain_tags(domain, limit):
     return domain, tags
 
 def main():
-    ap = argparse.ArgumentParser(description="Merge trending tags across bubble servers and select a subset.")
+    ap = argparse.ArgumentParser(description="Merge trending tags across seed list servers and select a subset.")
     ap.add_argument("--domains-file", default="trendy_domains.txt", help="Path to trendy domains list")
     ap.add_argument("--limit-per-domain", type=int, default=40, help="Fetch up to this many tags per domain")
     ap.add_argument("--select", type=int, default=10, help="Automatically pick top N merged tags")
@@ -101,7 +101,7 @@ def main():
     merged = sorted(aggregate.items(), key=lambda kv: kv[1], reverse=True)
 
     # Print a preview
-    print("\n=== Bubble-wide trending (merged) ===")
+    print("\n=== Seed list trending (merged) ===")
     for i, (tag, score) in enumerate(merged[:100], 1):
         print(f"{i:2}. #{tag}  — score {score}")
 

--- a/sharkey_ads/pipeline.py
+++ b/sharkey_ads/pipeline.py
@@ -1,0 +1,112 @@
+import os
+import json
+import time
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+from typing import Dict, Iterable, List, Tuple
+
+from .bubble_trends import load_domains, fetch_domain_tags
+from .ads_stage_uploads import main as upload_main, is_nsfw_tag
+from .ad_stage_create_ad import main as create_ad_main
+
+
+def prompt_domains(path: Path) -> List[str]:
+    """Load the seed list from *path* and let the user add/remove domains."""
+
+    domains = load_domains(str(path))
+    print("Current seed list:")
+    for d in domains:
+        print(f" - {d}")
+    add = input("Add domains (comma separated, blank to skip): ").strip()
+    if add:
+        for d in add.split(","):
+            d = d.strip().lower()
+            if d and d not in domains:
+                domains.append(d)
+    remove = input("Remove domains (comma separated, blank to skip): ").strip()
+    if remove:
+        for d in remove.split(","):
+            d = d.strip().lower()
+            if d in domains:
+                domains.remove(d)
+    print("\nUsing seed list:")
+    for d in domains:
+        print(f" - {d}")
+    if input("Proceed? [y/N]: ").strip().lower() != "y":
+        print("Aborted.")
+        raise SystemExit(1)
+    path.write_text("\n".join(domains) + "\n", encoding="utf-8")
+    return domains
+
+
+def fetch_and_merge(domains: Iterable[str], limit: int = 40) -> Tuple[List[Tuple[str, int]], Dict[str, List[Tuple[str, int]]]]:
+    """Fetch trending tags for each domain and merge them, filtering NSFW tags."""
+
+    domain_list = list(domains)
+    totals: Dict[str, int] = defaultdict(int)
+    per_domain: Dict[str, List[Tuple[str, int]]] = {}
+    max_workers = min(8, max(1, len(domain_list)))
+    with ThreadPoolExecutor(max_workers=max_workers) as exe:
+        futs = [exe.submit(fetch_domain_tags, d, limit) for d in domain_list]
+        for fut in as_completed(futs):
+            d, tags = fut.result()
+            per_domain[d] = tags
+            for name, score in tags:
+                norm = name.lstrip("#").lower()
+                if not norm or is_nsfw_tag(norm):
+                    continue
+                totals[norm] += int(score)
+    merged = sorted(totals.items(), key=lambda kv: kv[1], reverse=True)
+    return merged, per_domain
+
+
+def main() -> None:
+    """Run the interactive pipeline from seed list to ad creation."""
+
+    base = Path(__file__).resolve().parents[1]
+    domains_path = base / "trendy_domains.txt"
+    domains = prompt_domains(domains_path)
+
+    merged, per_domain = fetch_and_merge(domains)
+    print("\n=== Seed list trending (merged) ===")
+    for i, (tag, score) in enumerate(merged[:100], 1):
+        print(f"{i:2}. #{tag}  — score {score}")
+
+    try:
+        n = int(input("How many hashtags to select? ").strip() or "10")
+    except ValueError:
+        n = 10
+    selected = [t for t, _ in merged[:n]]
+
+    # Save results for downstream stages
+    (base / "selected_tags.txt").write_text("\n".join(selected) + "\n", encoding="utf-8")
+    trends_data = {
+        "generated_at": int(time.time()),
+        "domains": domains,
+        "per_domain": {
+            d: [{"tag": t, "score": s} for t, s in per_domain.get(d, [])]
+            for d in domains
+        },
+        "merged": [{"tag": t, "score": s} for t, s in merged],
+        "selected": [{"tag": t} for t in selected],
+    }
+    with open(base / "bubble_trends.json", "w", encoding="utf-8") as f:
+        json.dump(trends_data, f, ensure_ascii=False, indent=2)
+
+    duration_in = input("Ad duration in days (default 3): ").strip()
+    try:
+        duration = int(duration_in) if duration_in else 3
+    except ValueError:
+        duration = 3
+    os.environ["AD_DURATION_DAYS"] = str(duration)
+
+    print("\n[stage] Uploading images…")
+    upload_main()
+    print("\n[stage] Creating ads…")
+    create_ad_main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add interactive pipeline to manage seed list domains, fetch trending tags, and create ads
- rename references from "bubble" to "seed list" and clean up supporting modules
- integrate existing upload and ad creation stages

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba312d411c8327b0cad6fd65adb4cb